### PR TITLE
qemu_vm: add support for new on-fault mem-lock value

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3158,8 +3158,8 @@ class VM(virt_vm.BaseVM):
             add_qemu_option(devices, "msg", [attr_info])
         if params.get("realtime_mlock"):
             if devices.has_option("overcommit"):
-                attr_info = ["mem-lock", params["realtime_mlock"], bool]
-                add_qemu_option(devices, "overcommit", [attr_info])
+                cmd = "-overcommit mem-lock=%s" % params["realtime_mlock"]
+                devices.insert(StrDev("overcommit", cmdline=cmd))
             else:
                 attr_info = ["mlock", params["realtime_mlock"], bool]
                 add_qemu_option(devices, "realtime", [attr_info])


### PR DESCRIPTION
With the arrival of the value, on-fault, for the mem-lock value, updates the code so now supports new string values instead of only boolean ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the way memory overcommitment options are added to improve handling of the "realtime_mlock" parameter for virtual machines. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->