### PR TITLE
qemu_vm: add support for new on-fault mem-lock value

### DIFF
--- a/virttest/qemu_vm.py
+++ b/virttest/qemu_vm.py
@@ -3158,8 +3158,8 @@ class VM(virt_vm.BaseVM):
             add_qemu_option(devices, "msg", [attr_info])
         if params.get("realtime_mlock"):
             if devices.has_option("overcommit"):
-                attr_info = ["mem-lock", params["realtime_mlock"], bool]
-                add_qemu_option(devices, "overcommit", [attr_info])
+                cmd = "-overcommit mem-lock=%s" % params["realtime_mlock"]
+                devices.insert(StrDev("overcommit", cmdline=cmd))
             else:
                 attr_info = ["mlock", params["realtime_mlock"], bool]
                 add_qemu_option(devices, "realtime", [attr_info])


### PR DESCRIPTION
With the arrival of the value, on-fault, for the mem-lock value, updates the code so now supports new string values instead of only boolean ones.

## Summary by Sourcery

Enable support for new on-fault mem-lock values by updating overcommit option handling.

New Features:
- Add support for non-boolean mem-lock values (e.g., "on-fault") for the QEMU overcommit option.

Enhancements:
- Replace boolean-based add_qemu_option for mem-lock with direct StrDev insertion for the overcommit command.